### PR TITLE
Add workflow permissions

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -1,4 +1,6 @@
 name: Specs
+permissions:
+  contents: read
 on:
 - pull_request
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/hlascelles/bundler-resolutions/security/code-scanning/1](https://github.com/hlascelles/bundler-resolutions/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only needs to read the repository contents to check out the code and run tests, we will set `contents: read` as the minimal required permission. This ensures that no unnecessary write permissions are granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
